### PR TITLE
Fix code scanning alert no. 2: Unsafe jQuery plugin

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -505,8 +505,15 @@ var browser=function(){"use strict";var t={name:null,version:null,os:null,osVers
 			}, userConfig);
 
 			// Expand "target" if it's not a jQuery object already.
-				if (typeof config.target != 'jQuery')
-					config.target = $(config.target);
+				if (!(config.target instanceof jQuery) && typeof config.target !== 'string') {
+					config.target = $this;
+				} else {
+					try {
+						config.target = $(config.target);
+					} catch (e) {
+						config.target = $this;
+					}
+				}
 
 		// Panel.
 


### PR DESCRIPTION
Fixes [https://github.com/califool/adamshis.github.io/security/code-scanning/2](https://github.com/califool/adamshis.github.io/security/code-scanning/2)

To fix the problem, we need to ensure that the `config.target` is always a safe jQuery object or a valid CSS selector. We can achieve this by validating the `userConfig.target` before using it. If `userConfig.target` is not a valid jQuery object or a valid CSS selector, we should default to a safe value.

1. Validate `userConfig.target` to ensure it is a valid jQuery object or a valid CSS selector.
2. If `userConfig.target` is invalid, default to a safe value (e.g., the element itself).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
